### PR TITLE
Replace entityID with the RequesterID for the OIDC Clients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 [Added]
 - Use SimpleSAML\Database library
 - Support for PostgreSQL queries
+- Replace entityID with the RequesterID for the OIDC Clients
 
 ## [v2.0.0]
 [Added]

--- a/config-templates/module_statisticsproxy.php
+++ b/config-templates/module_statisticsproxy.php
@@ -106,4 +106,9 @@ $config = array(
 	 */
 	'serviceProvidersMapTableName' => 'serviceProvidersMap',
 
+    /*
+     * Fill the entityID of OpenID Connect Provider
+     */
+    'oidcIssuer' => 'http://example.org/openidconnect/sp',
+
 );

--- a/lib/Auth/Process/DatabaseCommand.php
+++ b/lib/Auth/Process/DatabaseCommand.php
@@ -23,8 +23,17 @@ class DatabaseCommand
             $idpEntityID = $request['Attributes']['authnAuthority'][0];
             $idpName = null;
         }
-        $spEntityId = $request['Destination']['entityid'];
-        $spName = $request['Destination']['name']['en'];
+        if (!empty($request['saml:RequesterID'])) {
+            if (!empty($databaseConnector->getOidcIssuer()) && (strpos($request['Destination']['entityid'], $databaseConnector->getOidcIssuer()) !== false)) {
+                $spEntityId = str_replace($databaseConnector->getOidcIssuer() . "/", "", $request['saml:RequesterID'][0]);
+            } else {
+                $spEntityId = $request['saml:RequesterID'][0];
+            }
+            $spName = $spEntityId; // TODO: Improve friendly name
+        } else {
+            $spEntityId = $request['Destination']['entityid'];
+            $spName = $request['Destination']['name']['en'];
+        }
         $year = $date->format('Y');
         $month = $date->format('m');
         $day = $date->format('d');

--- a/lib/Auth/Process/DatabaseConnector.php
+++ b/lib/Auth/Process/DatabaseConnector.php
@@ -9,12 +9,14 @@ class databaseConnector
 	private $statisticsTableName;
 	private $identityProvidersMapTableName;
 	private $serviceProvidersMapTableName;
+	private $oidcIss;
 
 	const CONFIG_FILE_NAME = 'module_statisticsproxy.php';
 	const USE_GLOBAL_CONFIG = 'useGlobalConfig';
 	const STATS_TABLE_NAME = 'statisticsTableName';
 	const IDP_MAP_TABLE_NAME = 'identityProvidersMapTableName';
 	const SP_MAP_TABLE_NAME = 'serviceProvidersMapTableName';
+	const OIDC_ISS = 'oidcIssuer';
 
 
 
@@ -25,6 +27,7 @@ class databaseConnector
 		$this->statisticsTableName = $conf->getString(self::STATS_TABLE_NAME);
 		$this->identityProvidersMapTableName = $conf->getString(self::IDP_MAP_TABLE_NAME);
 		$this->serviceProvidersMapTableName = $conf->getString(self::SP_MAP_TABLE_NAME);
+		$this->oidcIss = $conf->getString(self::OIDC_ISS, null);
 	}
 
 	public function getConnection()
@@ -63,6 +66,11 @@ class databaseConnector
 		$dsn = $config->getString('database.dsn');
 		preg_match('/.+?(?=:)/', $dsn, $driver);
 		return $driver[0];
+	}
+
+	public function getOidcIssuer()
+	{
+		return $this->oidcIss;
 	}
 
 }


### PR DESCRIPTION
The module doesn't display the OIDC clients as individual services and are displayed as one service (OIDC provider).
This fix separates the OIDC clients and replace the entityID of the OIDC provider with the requesterID which is included in the SAML authentication request from the OIDC provider.